### PR TITLE
Fix Lavalink URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ yarn add gorilink
 ```
 
 # About
-To use you need a configured [Lavalink](https://github.com/Frederikam/Lavalink) instance.
+To use you need a configured [Lavalink](https://github.com/freyacodes/Lavalink) instance.
 
 - Performant
 - 100% Compatible with Lavalink


### PR DESCRIPTION
I have changed my username. The old link refers to a fake repository that I have no control over